### PR TITLE
[REFACTOR] Kok 관련 Null 예외처리를 직접하지 않고, Optional값으로 처리하도록 수정

### DIFF
--- a/src/main/java/com/project/zipkok/repository/KokRepository.java
+++ b/src/main/java/com/project/zipkok/repository/KokRepository.java
@@ -30,7 +30,7 @@ public interface KokRepository extends JpaRepository<Kok, Long> {
             "FROM Kok k " +
             "LEFT JOIN Zim z ON k.user.userId = z.user.userId AND k.realEstate.realEstateId = z.realEstate.realEstateId " +
             "WHERE k.user.userId = :userId ")
-    List<GetKokWithZimStatus> getKokWithZimStatus(@Param("userId") long userId, Pageable pageable);
+    Slice<GetKokWithZimStatus> getKokWithZimStatus(@Param("userId") long userId, Pageable pageable);
 
     @Query("SELECT k "
             + "FROM Kok k "

--- a/src/main/java/com/project/zipkok/repository/KokRepository.java
+++ b/src/main/java/com/project/zipkok/repository/KokRepository.java
@@ -12,12 +12,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Repository
 public interface KokRepository extends JpaRepository<Kok, Long> {
 
-    Kok findByKokId(long kokId);
+    Optional<Kok> findByKokId(long kokId);
 
     @Query(value = "select new com.project.zipkok.dto.GetKokWithZimStatus(k, " +
             "CASE " +
@@ -36,7 +37,7 @@ public interface KokRepository extends JpaRepository<Kok, Long> {
             + "JOIN FETCH cdo.detailOption do "
             + "WHERE k.kokId = :kokId"
     )
-    Kok findKokWithCheckedOptionAndCheckedDetailOption(Long kokId);
+    Optional<Kok> findKokWithCheckedOptionAndCheckedDetailOption(Long kokId);
 
     @Query("SELECT k "
             + "FROM Kok k "
@@ -45,5 +46,5 @@ public interface KokRepository extends JpaRepository<Kok, Long> {
             + "JOIN FETCH ci.impression i "
             + "WHERE k.kokId = :kokId"
     )
-    Kok findKokWithImpressionAndStar(Long kokId);
+    Optional<Kok> findKokWithImpressionAndStar(Long kokId);
 }

--- a/src/main/java/com/project/zipkok/repository/KokRepository.java
+++ b/src/main/java/com/project/zipkok/repository/KokRepository.java
@@ -16,12 +16,8 @@ import java.util.List;
 
 @Repository
 public interface KokRepository extends JpaRepository<Kok, Long> {
-    boolean existsByUserAndRealEstate(User user, RealEstate realEstate);
 
     Kok findByKokId(long kokId);
-
-    @Query("SELECT k FROM Kok k JOIN FETCH k.realEstate WHERE k.user.userId = :userId")
-    Slice<Kok> findByUserId(long userId, org.springframework.data.domain.Pageable pageable);
 
     @Query(value = "select new com.project.zipkok.dto.GetKokWithZimStatus(k, " +
             "CASE " +

--- a/src/main/java/com/project/zipkok/repository/KokRepository.java
+++ b/src/main/java/com/project/zipkok/repository/KokRepository.java
@@ -2,8 +2,6 @@ package com.project.zipkok.repository;
 
 import com.project.zipkok.dto.GetKokWithZimStatus;
 import com.project.zipkok.model.Kok;
-import com.project.zipkok.model.RealEstate;
-import com.project.zipkok.model.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 

--- a/src/main/java/com/project/zipkok/service/KokService.java
+++ b/src/main/java/com/project/zipkok/service/KokService.java
@@ -72,7 +72,8 @@ public class KokService {
         log.info("[KokService.getKokOuterInfo]");
 
         User user = userRepository.findByUserId(userId);
-        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId);
+        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId)
+                .orElseThrow(() -> new KokException(KOK_ID_NOT_FOUND));
 
         validateUserAndKok(user, kok);
 
@@ -84,7 +85,8 @@ public class KokService {
         log.info("[KokService.getKokInnerInfo]");
 
         User user = userRepository.findByUserId(userId);
-        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId);
+        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId)
+                .orElseThrow(() -> new KokException(KOK_ID_NOT_FOUND));
 
         validateUserAndKok(user, kok);
 
@@ -96,7 +98,8 @@ public class KokService {
         log.info("[KokService.getKokContractInfo]");
 
         User user = userRepository.findByUserId(userId);
-        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId);
+        Kok kok = kokRepository.findKokWithCheckedOptionAndCheckedDetailOption(kokId)
+                .orElseThrow(() -> new KokException(KOK_ID_NOT_FOUND));
 
         validateUserAndKok(user, kok);
 
@@ -108,7 +111,8 @@ public class KokService {
         log.info("[KokService.getKokReviewInfo]");
 
         User user = userRepository.findByUserId(userId);
-        Kok kok = kokRepository.findKokWithImpressionAndStar(kokId);
+        Kok kok = kokRepository.findKokWithImpressionAndStar(kokId)
+                .orElseThrow(() -> new KokException(KOK_ID_NOT_FOUND));
 
         validateUserAndKok(user, kok);
 
@@ -122,7 +126,7 @@ public class KokService {
         User user = userRepository.findByUserId(userId);
 
         if(kokId != null) {
-            Kok kok = kokRepository.findByKokId(kokId);
+            Kok kok = kokRepository.findByKokId(kokId).orElseThrow(() -> new KokException(KOK_ID_NOT_FOUND));
             validateUserAndKok(user, kok);
             return makeKokConfigResponse(user, kok);
         }
@@ -203,10 +207,6 @@ public class KokService {
     }
 
     private static void validateUserAndKok(User user, Kok kok) {
-
-        if (kok == null) {
-            throw new KokException(KOK_ID_NOT_FOUND);
-        }
 
         if (!kok.getUser().equals(user)) {
             throw new KokException(INVALID_KOK_ACCESS);

--- a/src/main/java/com/project/zipkok/service/KokService.java
+++ b/src/main/java/com/project/zipkok/service/KokService.java
@@ -42,7 +42,7 @@ public class KokService {
 
         log.info("[KokService.getKoks]");
 
-        List<GetKokWithZimStatus> getKokWithZimStatus = kokRepository.getKokWithZimStatus(userId, pageable);
+        List<GetKokWithZimStatus> getKokWithZimStatus = kokRepository.getKokWithZimStatus(userId, pageable).toList();
 
         return GetKokResponse.from(getKokWithZimStatus);
     }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

* ### 작업 동기
    * Kok 관련 Null 예외처리를 직접하지 않고, Optional값으로 처리하도록 수정
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->

## 변경 사항
1. KokRepository의 쿼리 결과를 Optional로 감싸 Null에 대한 예외 처리를 더 안전하게 하도록 수정
2. 페이지네이션 된 쿼리 결과를 List가 아닌 Slice로 받아오도록 수정
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->

* ### 주안점
    * Null에 대한 예외처리를 직접하는 것은 위험하기 때문에, Null값이 바인딩 될 수 있는 경우, 해당 객체를 Optional로 한번 감싸주는 것이 좋다.  
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->

* ### 설명
<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->


## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
